### PR TITLE
feat(deck-gen): 實作 LGP 模式支援單卡/雙卡卡組生成

### DIFF
--- a/MainBatch.py
+++ b/MainBatch.py
@@ -762,13 +762,22 @@ if __name__ == "__main__":
 
         logger.info("Pre-calculating deck amount...")
 
+        # 判斷是否使用雙卡模式（LGP）
+        if use_yaml_config and yaml_config:
+            allow_double_cards = yaml_config.get_lgp_mode()
+        else:
+            allow_double_cards = True  # 預設使用雙卡模式（向下相容）
+
+        logger.info(f"卡組生成模式: {'LGP（允許雙卡）' if allow_double_cards else '日常（單卡規則）'}")
+
         # 3. 获取卡组生成器
         decks_generator = generate_decks_with_double_cards(
             cardpool=current_card_ids,
             mustcards=[mustcards_all, mustcards_any, mustskills_all],
             center_char=pre_initialized_chart.music.CenterCharacterId,
             force_dr=force_dr,
-            log_path=os.path.join(FINAL_OUTPUT_DIR, f"simulation_results_{fixed_music_id}_{fixed_difficulty}.json")
+            log_path=os.path.join(FINAL_OUTPUT_DIR, f"simulation_results_{fixed_music_id}_{fixed_difficulty}.json"),
+            allow_double_cards=allow_double_cards
         )
         total_decks_to_simulate = decks_generator.total_decks
         logger.info(f"{total_decks_to_simulate} decks to be simulated.")

--- a/config/default-example.yaml
+++ b/config/default-example.yaml
@@ -84,8 +84,15 @@ card_ids:
   - 1023521
   - 1033528
 
-# 賽季模式
-season_mode: "sukushow"        # sukushow 或其他模式
+# 賽季模式 (用於計算粉絲等級加成)
+# - "sukushow": 只計算歌唱成員 (預設)
+# - "sukuste": 計算所有成員
+season_mode: "sukushow"
+
+# LGP 模式 (是否允許同角色雙卡)
+# - false: 日常模式，每個角色最多1張卡
+# - true: LGP 大賽模式，允許0-3個角色使用雙卡 (預設)
+lgp_mode: true
 
 # 粉絲等級配置 (用於 Season Fan Lv bonus)
 fan_levels:

--- a/config/dev-example.yaml
+++ b/config/dev-example.yaml
@@ -45,7 +45,13 @@ card_ids:
   - 1021701
   - 1033515
 
+# 賽季模式 (用於計算粉絲等級加成)
 season_mode: "sukushow"
+
+# LGP 模式 (是否允許同角色雙卡)
+# - false: 日常模式，每個角色最多1張卡
+# - true: LGP 大賽模式，允許0-3個角色使用雙卡 (預設)
+lgp_mode: true
 
 fan_levels:
   1011: 0

--- a/config/member-example.yaml
+++ b/config/member-example.yaml
@@ -62,7 +62,15 @@ card_ids:
   - 1052901  # BR塞
   - 1052503  # 十六夜塞
 
+# 賽季模式 (用於計算粉絲等級加成)
+# - "sukushow": 只計算歌唱成員 (預設)
+# - "sukuste": 計算所有成員
 season_mode: "sukushow"
+
+# LGP 模式 (是否允許同角色雙卡)
+# - false: 日常模式，每個角色最多1張卡
+# - true: LGP 大賽模式，允許0-3個角色使用雙卡 (預設)
+lgp_mode: true
 
 # Alice 的粉絲等級
 fan_levels:

--- a/src/config/config_manager.py
+++ b/src/config/config_manager.py
@@ -207,10 +207,10 @@ class ConfigManager:
         獲取 LGP 模式（是否允許雙卡）
 
         Returns:
-            True: LGP 大賽模式，允許同角色雙卡
-            False: 日常模式，每個角色最多1張卡（預設）
+            True: LGP 大賽模式，允許同角色雙卡（預設）
+            False: 日常模式，每個角色最多1張卡
         """
-        return self.config.get("lgp_mode", False)
+        return self.config.get("lgp_mode", True)
 
     def get_batch_size(self) -> int:
         """獲取批次大小"""

--- a/src/config/config_manager.py
+++ b/src/config/config_manager.py
@@ -199,8 +199,18 @@ class ConfigManager:
         return self.config.get("debug_deck_cards", None)
 
     def get_season_mode(self) -> str:
-        """獲取賽季模式"""
+        """獲取賽季模式（用於計算粉絲等級加成）"""
         return self.config.get("season_mode", "sukushow")
+
+    def get_lgp_mode(self) -> bool:
+        """
+        獲取 LGP 模式（是否允許雙卡）
+
+        Returns:
+            True: LGP 大賽模式，允許同角色雙卡
+            False: 日常模式，每個角色最多1張卡（預設）
+        """
+        return self.config.get("lgp_mode", False)
 
     def get_batch_size(self) -> int:
         """獲取批次大小"""
@@ -272,6 +282,7 @@ class ConfigManager:
         logger.info(f"歌曲數量: {len(self.get_songs_config())}")
         logger.info(f"卡牌數量: {len(self.get_card_ids())}")
         logger.info(f"賽季模式: {self.get_season_mode()}")
+        logger.info(f"LGP 模式: {'啟用（允許雙卡）' if self.get_lgp_mode() else '停用（單卡規則）'}")
         logger.info("=" * 60)
 
 

--- a/web/config-generator.html
+++ b/web/config-generator.html
@@ -625,6 +625,21 @@
                 </div>
             </div>
 
+            <!-- LGP 模式設定 -->
+            <div class="section">
+                <h2 class="section-title">LGP 模式（雙卡規則）</h2>
+                <div class="input-row">
+                    <div class="form-group">
+                        <label for="lgp-mode">啟用 LGP 模式</label>
+                        <select id="lgp-mode">
+                            <option value="false">停用（日常單卡規則）</option>
+                            <option value="true" selected>啟用（LGP 大賽雙卡規則，預設）</option>
+                        </select>
+                        <p class="help-text">⚠️ LGP 模式允許同角色雙卡（0-3個角色可雙卡），計算量較大。日常使用建議停用以節省計算時間。</p>
+                    </div>
+                </div>
+            </div>
+
             <!-- 歌曲配置 -->
             <div class="section">
                 <h2 class="section-title">歌曲配置</h2>

--- a/web/config-generator.js
+++ b/web/config-generator.js
@@ -945,8 +945,16 @@ songs:
         yaml += ` # ...\n`;
     }
 
-    yaml += `\n# 遊戲模式 (固定為 sukushow)\n`;
+    yaml += `\n# 賽季模式 (用於計算粉絲等級加成)\n`;
+    yaml += `# - "sukushow": 只計算歌唱成員 (預設)\n`;
+    yaml += `# - "sukuste": 計算所有成員\n`;
     yaml += `season_mode: "sukushow"\n\n`;
+
+    yaml += `# LGP 模式 (是否允許同角色雙卡)\n`;
+    yaml += `# - false: 日常模式，每個角色最多1張卡\n`;
+    yaml += `# - true: LGP 大賽模式，允許0-3個角色使用雙卡 (預設)\n`;
+    const lgpMode = document.getElementById('lgp-mode').value === 'true';
+    yaml += `lgp_mode: ${lgpMode}\n\n`;
 
     // 粉絲等級
     const fanLevelFullNames = {
@@ -1591,6 +1599,11 @@ function loadConfigToForm(config) {
             if (song.color_override) document.getElementById(`color-override-${songId}`).value = song.color_override;
             if (song.leader_designation) document.getElementById(`leader-designation-${songId}`).value = song.leader_designation;
         });
+    }
+
+    // 載入 LGP 模式
+    if (config.lgp_mode !== undefined) {
+        document.getElementById('lgp-mode').value = config.lgp_mode ? 'true' : 'false';
     }
 
     // 載入進階配置


### PR DESCRIPTION
- 新增 lgp_mode 配置參數，切換日常（單卡）與 LGP（雙卡）模式
- 修改 DeckGen2 支援單卡與雙卡生成邏輯
- 更新配置系統讀取並應用 lgp_mode
- 網頁配置生成器新增 LGP 模式開關
- 日常模式：無 DR 數量限制，每個角色最多 1 張卡
- LGP 模式：DR ≤ 1，允許 0-3 個角色雙卡
- 預設使用雙卡模式以保持向下相容性

Change-Id: I239928e1b755a0b869cb026f6d56bb17aeebe819