### PR TITLE
feat(banned-cards): 實作每首歌獨立禁卡功能

### DIFF
--- a/Data/CardDatas.json
+++ b/Data/CardDatas.json
@@ -9902,6 +9902,138 @@
       30315344
     ]
   },
+  "1031535": {
+    "CardSeriesId": 1031535,
+    "Name": "Poupée en Lotus",
+    "Description": "日野下 花帆",
+    "CharactersId": 1031,
+    "Rarity": 5,
+    "CenterSkillSeriesId": 10315350,
+    "CenterAttributeSeriesId": 20315350,
+    "MaxSmile": [
+      2575,
+      3605,
+      5150,
+      5665,
+      6180
+    ],
+    "MaxPure": [
+      2950,
+      4130,
+      5900,
+      6490,
+      7080
+    ],
+    "MaxCool": [
+      1650,
+      2310,
+      3300,
+      3630,
+      3960
+    ],
+    "MaxMental": [
+      243,
+      340,
+      485,
+      485,
+      485
+    ],
+    "RhythmGameSkillSeriesId": [
+      30315350,
+      30315350,
+      30315352,
+      30315353,
+      30315354
+    ]
+  },
+  "1031536": {
+    "CardSeriesId": 1031536,
+    "Name": "雪舞う空と二秒の永遠",
+    "Description": "日野下 花帆",
+    "CharactersId": 1031,
+    "Rarity": 5,
+    "CenterSkillSeriesId": 10315360,
+    "CenterAttributeSeriesId": 20315360,
+    "MaxSmile": [
+      2000,
+      2800,
+      4000,
+      4400,
+      4800
+    ],
+    "MaxPure": [
+      2500,
+      3500,
+      5000,
+      5500,
+      6000
+    ],
+    "MaxCool": [
+      3450,
+      4830,
+      6900,
+      7590,
+      8280
+    ],
+    "MaxMental": [
+      265,
+      371,
+      530,
+      530,
+      530
+    ],
+    "RhythmGameSkillSeriesId": [
+      30315360,
+      30315360,
+      30315362,
+      30315363,
+      30315364
+    ]
+  },
+  "1031537": {
+    "CardSeriesId": 1031537,
+    "Name": "Sayo-Shigure",
+    "Description": "日野下 花帆",
+    "CharactersId": 1031,
+    "Rarity": 5,
+    "CenterSkillSeriesId": 10315370,
+    "CenterAttributeSeriesId": 20315370,
+    "MaxSmile": [
+      2100,
+      2940,
+      4200,
+      4620,
+      5040
+    ],
+    "MaxPure": [
+      2500,
+      3500,
+      5000,
+      5500,
+      6000
+    ],
+    "MaxCool": [
+      2550,
+      3570,
+      5100,
+      5610,
+      6120
+    ],
+    "MaxMental": [
+      245,
+      343,
+      490,
+      490,
+      490
+    ],
+    "RhythmGameSkillSeriesId": [
+      30315370,
+      30315370,
+      30315372,
+      30315373,
+      30315374
+    ]
+  },
   "1031801": {
     "CardSeriesId": 1031801,
     "Name": "Prism Echo",
@@ -12825,6 +12957,50 @@
       30325324
     ]
   },
+  "1032533": {
+    "CardSeriesId": 1032533,
+    "Name": "雪舞う空と二秒の永遠",
+    "Description": "村野 さやか",
+    "CharactersId": 1032,
+    "Rarity": 5,
+    "CenterSkillSeriesId": 10325330,
+    "CenterAttributeSeriesId": 20325330,
+    "MaxSmile": [
+      2025,
+      2835,
+      4050,
+      4455,
+      4860
+    ],
+    "MaxPure": [
+      2500,
+      3500,
+      5000,
+      5500,
+      6000
+    ],
+    "MaxCool": [
+      3425,
+      4795,
+      6850,
+      7535,
+      8220
+    ],
+    "MaxMental": [
+      265,
+      371,
+      530,
+      530,
+      530
+    ],
+    "RhythmGameSkillSeriesId": [
+      30325330,
+      30325330,
+      30325332,
+      30325333,
+      30325334
+    ]
+  },
   "1032801": {
     "CardSeriesId": 1032801,
     "Name": "Prism Echo",
@@ -15225,6 +15401,138 @@
       30335294
     ]
   },
+  "1033530": {
+    "CardSeriesId": 1033530,
+    "Name": "Poupée en Lotus",
+    "Description": "大沢 瑠璃乃",
+    "CharactersId": 1033,
+    "Rarity": 5,
+    "CenterSkillSeriesId": 10335300,
+    "CenterAttributeSeriesId": 20335300,
+    "MaxSmile": [
+      2575,
+      3605,
+      5150,
+      5665,
+      6180
+    ],
+    "MaxPure": [
+      3025,
+      4235,
+      6050,
+      6655,
+      7260
+    ],
+    "MaxCool": [
+      1575,
+      2205,
+      3150,
+      3465,
+      3780
+    ],
+    "MaxMental": [
+      243,
+      340,
+      485,
+      485,
+      485
+    ],
+    "RhythmGameSkillSeriesId": [
+      30335300,
+      30335300,
+      30335302,
+      30335303,
+      30335304
+    ]
+  },
+  "1033531": {
+    "CardSeriesId": 1033531,
+    "Name": "Hip, hip, hooray!",
+    "Description": "大沢 瑠璃乃",
+    "CharactersId": 1033,
+    "Rarity": 5,
+    "CenterSkillSeriesId": 10335310,
+    "CenterAttributeSeriesId": 20335310,
+    "MaxSmile": [
+      3125,
+      4375,
+      6250,
+      6875,
+      7500
+    ],
+    "MaxPure": [
+      2525,
+      3535,
+      5050,
+      5555,
+      6060
+    ],
+    "MaxCool": [
+      1550,
+      2170,
+      3100,
+      3410,
+      3720
+    ],
+    "MaxMental": [
+      240,
+      336,
+      480,
+      480,
+      480
+    ],
+    "RhythmGameSkillSeriesId": [
+      30335310,
+      30335310,
+      30335312,
+      30335313,
+      30335314
+    ]
+  },
+  "1033532": {
+    "CardSeriesId": 1033532,
+    "Name": "雪舞う空と二秒の永遠",
+    "Description": "大沢 瑠璃乃",
+    "CharactersId": 1033,
+    "Rarity": 5,
+    "CenterSkillSeriesId": 10335320,
+    "CenterAttributeSeriesId": 20335320,
+    "MaxSmile": [
+      1975,
+      2765,
+      3950,
+      4345,
+      4740
+    ],
+    "MaxPure": [
+      2500,
+      3500,
+      5000,
+      5500,
+      6000
+    ],
+    "MaxCool": [
+      3475,
+      4865,
+      6950,
+      7645,
+      8340
+    ],
+    "MaxMental": [
+      265,
+      371,
+      530,
+      530,
+      530
+    ],
+    "RhythmGameSkillSeriesId": [
+      30335320,
+      30335320,
+      30335322,
+      30335323,
+      30335324
+    ]
+  },
   "1033801": {
     "CardSeriesId": 1033801,
     "Name": "Prism Echo",
@@ -15770,6 +16078,50 @@
       30414042,
       30414043,
       30414044
+    ]
+  },
+  "1041405": {
+    "CardSeriesId": 1041405,
+    "Name": "My Lucky Clover",
+    "Description": "百生 吟子",
+    "CharactersId": 1041,
+    "Rarity": 4,
+    "CenterSkillSeriesId": 10414050,
+    "CenterAttributeSeriesId": 20414050,
+    "MaxSmile": [
+      2075,
+      2905,
+      4150,
+      4565,
+      4980
+    ],
+    "MaxPure": [
+      2350,
+      3290,
+      4700,
+      5170,
+      5640
+    ],
+    "MaxCool": [
+      1775,
+      2485,
+      3550,
+      3905,
+      4260
+    ],
+    "MaxMental": [
+      220,
+      308,
+      440,
+      440,
+      440
+    ],
+    "RhythmGameSkillSeriesId": [
+      30414050,
+      30414050,
+      30414052,
+      30414053,
+      30414054
     ]
   },
   "1041501": {
@@ -16652,6 +17004,89 @@
       30415204
     ]
   },
+  "1041521": {
+    "CardSeriesId": 1041521,
+    "Name": "もういちど ルミナス",
+    "Description": "百生 吟子",
+    "CharactersId": 1041,
+    "Rarity": 5,
+    "CenterSkillSeriesId": 10415210,
+    "CenterAttributeSeriesId": 20415210,
+    "MaxSmile": [
+      3605,
+      5150,
+      5665,
+      6180
+    ],
+    "MaxPure": [
+      3850,
+      5500,
+      6050,
+      6600
+    ],
+    "MaxCool": [
+      2625,
+      3750,
+      4125,
+      4500
+    ],
+    "MaxMental": [
+      336,
+      480,
+      480,
+      480
+    ],
+    "RhythmGameSkillSeriesId": [
+      30415210,
+      30415212,
+      30415213,
+      30415214
+    ]
+  },
+  "1041522": {
+    "CardSeriesId": 1041522,
+    "Name": "Sayo-Shigure",
+    "Description": "百生 吟子",
+    "CharactersId": 1041,
+    "Rarity": 5,
+    "CenterSkillSeriesId": 10415220,
+    "CenterAttributeSeriesId": 20415220,
+    "MaxSmile": [
+      2025,
+      2835,
+      4050,
+      4455,
+      4860
+    ],
+    "MaxPure": [
+      2525,
+      3535,
+      5050,
+      5555,
+      6060
+    ],
+    "MaxCool": [
+      2600,
+      3640,
+      5200,
+      5720,
+      6240
+    ],
+    "MaxMental": [
+      245,
+      343,
+      490,
+      490,
+      490
+    ],
+    "RhythmGameSkillSeriesId": [
+      30415220,
+      30415220,
+      30415222,
+      30415223,
+      30415224
+    ]
+  },
   "1041801": {
     "CardSeriesId": 1041801,
     "Name": "Ether Aria",
@@ -17158,6 +17593,50 @@
       30424042,
       30424043,
       30424044
+    ]
+  },
+  "1042405": {
+    "CardSeriesId": 1042405,
+    "Name": "diamondz",
+    "Description": "徒町 小鈴",
+    "CharactersId": 1042,
+    "Rarity": 4,
+    "CenterSkillSeriesId": 10424050,
+    "CenterAttributeSeriesId": 20424050,
+    "MaxSmile": [
+      2200,
+      3080,
+      4400,
+      4840,
+      5280
+    ],
+    "MaxPure": [
+      2325,
+      3255,
+      4650,
+      5115,
+      5580
+    ],
+    "MaxCool": [
+      1675,
+      2345,
+      3350,
+      3685,
+      4020
+    ],
+    "MaxMental": [
+      220,
+      308,
+      440,
+      440,
+      440
+    ],
+    "RhythmGameSkillSeriesId": [
+      30424050,
+      30424050,
+      30424052,
+      30424053,
+      30424054
     ]
   },
   "1042501": {
@@ -17996,6 +18475,89 @@
       30425194
     ]
   },
+  "1042520": {
+    "CardSeriesId": 1042520,
+    "Name": "Poupée en Lotus",
+    "Description": "徒町 小鈴",
+    "CharactersId": 1042,
+    "Rarity": 5,
+    "CenterSkillSeriesId": 10425200,
+    "CenterAttributeSeriesId": 20425200,
+    "MaxSmile": [
+      2650,
+      3710,
+      5300,
+      5830,
+      6360
+    ],
+    "MaxPure": [
+      2900,
+      4060,
+      5800,
+      6380,
+      6960
+    ],
+    "MaxCool": [
+      1625,
+      2275,
+      3250,
+      3575,
+      3900
+    ],
+    "MaxMental": [
+      243,
+      340,
+      485,
+      485,
+      485
+    ],
+    "RhythmGameSkillSeriesId": [
+      30425200,
+      30425200,
+      30425202,
+      30425203,
+      30425204
+    ]
+  },
+  "1042521": {
+    "CardSeriesId": 1042521,
+    "Name": "壱雫空",
+    "Description": "徒町 小鈴",
+    "CharactersId": 1042,
+    "Rarity": 5,
+    "CenterSkillSeriesId": 10425210,
+    "CenterAttributeSeriesId": 20425210,
+    "MaxSmile": [
+      2730,
+      3900,
+      4290,
+      4680
+    ],
+    "MaxPure": [
+      3395,
+      4850,
+      5335,
+      5820
+    ],
+    "MaxCool": [
+      3955,
+      5650,
+      6215,
+      6780
+    ],
+    "MaxMental": [
+      336,
+      480,
+      480,
+      480
+    ],
+    "RhythmGameSkillSeriesId": [
+      30425210,
+      30425212,
+      30425213,
+      30425214
+    ]
+  },
   "1042801": {
     "CardSeriesId": 1042801,
     "Name": "Ether Aria",
@@ -18507,6 +19069,50 @@
       30434052,
       30434053,
       30434054
+    ]
+  },
+  "1043406": {
+    "CardSeriesId": 1043406,
+    "Name": "ハートにQ",
+    "Description": "安養寺 姫芽",
+    "CharactersId": 1043,
+    "Rarity": 4,
+    "CenterSkillSeriesId": 10434060,
+    "CenterAttributeSeriesId": 20434060,
+    "MaxSmile": [
+      2000,
+      2800,
+      4000,
+      4400,
+      4800
+    ],
+    "MaxPure": [
+      2300,
+      3220,
+      4600,
+      5060,
+      5520
+    ],
+    "MaxCool": [
+      1850,
+      2590,
+      3700,
+      4070,
+      4440
+    ],
+    "MaxMental": [
+      225,
+      315,
+      450,
+      450,
+      450
+    ],
+    "RhythmGameSkillSeriesId": [
+      30434060,
+      30434060,
+      30434062,
+      30434063,
+      30434064
     ]
   },
   "1043501": {
@@ -19345,6 +19951,89 @@
       30435194
     ]
   },
+  "1043520": {
+    "CardSeriesId": 1043520,
+    "Name": "キミがいなくちゃっ！",
+    "Description": "安養寺 姫芽",
+    "CharactersId": 1043,
+    "Rarity": 5,
+    "CenterSkillSeriesId": 10435200,
+    "CenterAttributeSeriesId": 20435200,
+    "MaxSmile": [
+      4130,
+      5900,
+      6490,
+      7080
+    ],
+    "MaxPure": [
+      3500,
+      5000,
+      5500,
+      6000
+    ],
+    "MaxCool": [
+      2310,
+      3300,
+      3630,
+      3960
+    ],
+    "MaxMental": [
+      350,
+      500,
+      500,
+      500
+    ],
+    "RhythmGameSkillSeriesId": [
+      30435200,
+      30435202,
+      30435203,
+      30435204
+    ]
+  },
+  "1043521": {
+    "CardSeriesId": 1043521,
+    "Name": "Hip, hip, hooray!",
+    "Description": "安養寺 姫芽",
+    "CharactersId": 1043,
+    "Rarity": 5,
+    "CenterSkillSeriesId": 10435210,
+    "CenterAttributeSeriesId": 20435210,
+    "MaxSmile": [
+      3100,
+      4340,
+      6200,
+      6820,
+      7440
+    ],
+    "MaxPure": [
+      2600,
+      3640,
+      5200,
+      5720,
+      6240
+    ],
+    "MaxCool": [
+      1500,
+      2100,
+      3000,
+      3300,
+      3600
+    ],
+    "MaxMental": [
+      240,
+      336,
+      480,
+      480,
+      480
+    ],
+    "RhythmGameSkillSeriesId": [
+      30435210,
+      30435210,
+      30435212,
+      30435213,
+      30435214
+    ]
+  },
   "1043801": {
     "CardSeriesId": 1043801,
     "Name": "Ether Aria",
@@ -20073,6 +20762,89 @@
       30515074
     ]
   },
+  "1051508": {
+    "CardSeriesId": 1051508,
+    "Name": "FIRE BIRD",
+    "Description": "桂城 泉",
+    "CharactersId": 1051,
+    "Rarity": 5,
+    "CenterSkillSeriesId": 10515080,
+    "CenterAttributeSeriesId": 20515080,
+    "MaxSmile": [
+      2870,
+      4100,
+      4510,
+      4920
+    ],
+    "MaxPure": [
+      3255,
+      4650,
+      5115,
+      5580
+    ],
+    "MaxCool": [
+      4095,
+      5850,
+      6435,
+      7020
+    ],
+    "MaxMental": [
+      322,
+      460,
+      460,
+      460
+    ],
+    "RhythmGameSkillSeriesId": [
+      30515080,
+      30515082,
+      30515083,
+      30515084
+    ]
+  },
+  "1051509": {
+    "CardSeriesId": 1051509,
+    "Name": "令嬢モブ！",
+    "Description": "桂城 泉",
+    "CharactersId": 1051,
+    "Rarity": 5,
+    "CenterSkillSeriesId": 10515090,
+    "CenterAttributeSeriesId": 20515090,
+    "MaxSmile": [
+      2300,
+      3220,
+      4600,
+      5060,
+      5520
+    ],
+    "MaxPure": [
+      1650,
+      2310,
+      3300,
+      3630,
+      3960
+    ],
+    "MaxCool": [
+      3300,
+      4620,
+      6600,
+      7260,
+      7920
+    ],
+    "MaxMental": [
+      235,
+      329,
+      470,
+      470,
+      470
+    ],
+    "RhythmGameSkillSeriesId": [
+      30515090,
+      30515090,
+      30515092,
+      30515093,
+      30515094
+    ]
+  },
   "1051801": {
     "CardSeriesId": 1051801,
     "Name": "Oracle Étude",
@@ -20110,6 +20882,45 @@
       30518012,
       30518013,
       30518014
+    ]
+  },
+  "1051901": {
+    "CardSeriesId": 1051901,
+    "Name": "17th Birthday",
+    "Description": "桂城 泉",
+    "CharactersId": 1051,
+    "Rarity": 9,
+    "CenterSkillSeriesId": 10519010,
+    "CenterAttributeSeriesId": 20519010,
+    "MaxSmile": [
+      3360,
+      4800,
+      5280,
+      5760
+    ],
+    "MaxPure": [
+      3360,
+      4800,
+      5280,
+      5760
+    ],
+    "MaxCool": [
+      3360,
+      4800,
+      5280,
+      5760
+    ],
+    "MaxMental": [
+      336,
+      480,
+      480,
+      480
+    ],
+    "RhythmGameSkillSeriesId": [
+      30519010,
+      30519012,
+      30519013,
+      30519014
     ]
   },
   "1052301": {
@@ -20638,6 +21449,94 @@
       30525072,
       30525073,
       30525074
+    ]
+  },
+  "1052508": {
+    "CardSeriesId": 1052508,
+    "Name": "105/刹那&セラニャン",
+    "Description": "セラス 柳田 リリエンフェルト",
+    "CharactersId": 1052,
+    "Rarity": 5,
+    "CenterSkillSeriesId": 10525080,
+    "CenterAttributeSeriesId": 20525080,
+    "MaxSmile": [
+      2075,
+      2905,
+      4150,
+      4565,
+      4980
+    ],
+    "MaxPure": [
+      2875,
+      4025,
+      5750,
+      6325,
+      6900
+    ],
+    "MaxCool": [
+      2150,
+      3010,
+      4300,
+      4730,
+      5160
+    ],
+    "MaxMental": [
+      250,
+      350,
+      500,
+      500,
+      500
+    ],
+    "RhythmGameSkillSeriesId": [
+      30525080,
+      30525080,
+      30525082,
+      30525083,
+      30525084
+    ]
+  },
+  "1052509": {
+    "CardSeriesId": 1052509,
+    "Name": "令嬢モブ！",
+    "Description": "セラス 柳田 リリエンフェルト",
+    "CharactersId": 1052,
+    "Rarity": 5,
+    "CenterSkillSeriesId": 10525090,
+    "CenterAttributeSeriesId": 20525090,
+    "MaxSmile": [
+      2350,
+      3290,
+      4700,
+      5170,
+      5640
+    ],
+    "MaxPure": [
+      1650,
+      2310,
+      3300,
+      3630,
+      3960
+    ],
+    "MaxCool": [
+      3250,
+      4550,
+      6500,
+      7150,
+      7800
+    ],
+    "MaxMental": [
+      235,
+      329,
+      470,
+      470,
+      470
+    ],
+    "RhythmGameSkillSeriesId": [
+      30525090,
+      30525090,
+      30525092,
+      30525093,
+      30525094
     ]
   },
   "1052801": {

--- a/Data/Musics.yaml
+++ b/Data/Musics.yaml
@@ -525,7 +525,7 @@
   IsVideoMode: 0
   VideoBgId: 0
   SongType: 1
-  MusicScoreReleaseTime: 2035-12-31T14:59:59Z
+  MusicScoreReleaseTime: 2025-12-28T12:00:00Z
 - Id: 103117
   OrderId: 1213
   Title: シュガーメルト
@@ -789,7 +789,7 @@
   IsVideoMode: 0
   VideoBgId: 0
   SongType: 2
-  MusicScoreReleaseTime: 2035-12-31T14:59:59Z
+  MusicScoreReleaseTime: 2026-01-11T03:00:00Z
 - Id: 103205
   OrderId: 6019
   Title: ダイヤモンドハッピー
@@ -1218,7 +1218,7 @@
   IsVideoMode: 0
   VideoBgId: 0
   SongType: 1
-  MusicScoreReleaseTime: 2035-12-31T14:59:59Z
+  MusicScoreReleaseTime: 2025-11-30T03:00:00Z
 - Id: 104111
   OrderId: 1024
   Title: Link to the FUTURE（104期Ver.）
@@ -2373,7 +2373,7 @@
   IsVideoMode: 0
   VideoBgId: 0
   SongType: 1
-  MusicScoreReleaseTime: 2035-12-31T14:59:59Z
+  MusicScoreReleaseTime: 2025-12-19T03:00:00Z
 - Id: 203114
   OrderId: 1607
   Title: ミルク
@@ -2802,7 +2802,7 @@
   IsVideoMode: 0
   VideoBgId: 3
   SongType: 2
-  MusicScoreReleaseTime: 2035-12-31T14:59:59Z
+  MusicScoreReleaseTime: 2025-12-10T01:00:00Z
 - Id: 203301
   OrderId: 5001
   Title: 僕らのLIVE 君とのLIFE
@@ -4419,7 +4419,7 @@
   IsVideoMode: 0
   VideoBgId: 0
   SongType: 1
-  MusicScoreReleaseTime: 2035-12-31T14:59:59Z
+  MusicScoreReleaseTime: 2025-11-30T03:00:00Z
 - Id: 303116
   OrderId: 1413
   Title: 飴色
@@ -4485,7 +4485,7 @@
   IsVideoMode: 0
   VideoBgId: 0
   SongType: 1
-  MusicScoreReleaseTime: 2035-12-31T14:59:59Z
+  MusicScoreReleaseTime: 2025-12-10T01:00:00Z
 - Id: 303118
   OrderId: 2002
   Title: Pleasure Feather
@@ -4749,7 +4749,7 @@
   IsVideoMode: 0
   VideoBgId: 0
   SongType: 2
-  MusicScoreReleaseTime: 2035-12-31T14:59:59Z
+  MusicScoreReleaseTime: 2025-12-28T12:00:00Z
 - Id: 303207
   OrderId: 6020
   Title: lucky train!
@@ -5574,7 +5574,7 @@
   IsVideoMode: 0
   VideoBgId: 0
   SongType: 2
-  MusicScoreReleaseTime: 2035-12-31T14:59:59Z
+  MusicScoreReleaseTime: 2025-12-05T03:00:00Z
 - Id: 304203
   OrderId: 6026
   Title: 雑踏、僕らの街
@@ -6495,8 +6495,8 @@
   StartTime: 2022-12-31T15:00:00Z
   EndTime: 2035-12-31T14:59:00Z
   MaxAp: 20
-  IsVideoMode: 0
-  VideoBgId: 0
+  IsVideoMode: 1
+  VideoBgId: 1
   SongType: 1
   MusicScoreReleaseTime: 2025-10-31T12:00:00Z
 - Id: 405120
@@ -6594,8 +6594,8 @@
   StartTime: 2022-12-31T15:00:00Z
   EndTime: 2035-12-31T14:59:00Z
   MaxAp: 20
-  IsVideoMode: 0
-  VideoBgId: 0
+  IsVideoMode: 1
+  VideoBgId: 3
   SongType: 1
   MusicScoreReleaseTime: 2025-11-09T12:00:00Z
 - Id: 405123
@@ -6693,10 +6693,406 @@
   StartTime: 2022-12-31T15:00:00Z
   EndTime: 2035-12-31T14:59:00Z
   MaxAp: 20
+  IsVideoMode: 1
+  VideoBgId: 2
+  SongType: 1
+  MusicScoreReleaseTime: 2025-11-20T12:00:00Z
+- Id: 405126
+  OrderId: 1041
+  Title: チャーミングな花束を！
+  TitleFurigana: ちゃーみんぐなはなたばを
+  JacketId: 405126
+  SoundId: 40512601
+  Description: 全体曲
+  GenerationsId: 105
+  UnitId: 100
+  CenterCharacterId: 1031
+  SingerCharacterId: 1032,1033,1041,1042,1043,1051,1052
+  SupportCharacterId: "0"
+  MusicType: 1
+  ExperienceType: 1
+  BeatPointCoefficient: 13846
+  ApIncrement: 953
+  SongTime: 9530
+  PlayTime: 114362
+  FeverSectionNo: 5
+  PreviewStartTime: 10000
+  PreviewEndTime: 15000
+  PreviewFadeInTime: 11000
+  PreviewFadeOutTime: 14000
+  ReleaseConditionType: 0
+  ReleaseConditionDetail: 0
+  ReleaseConditionText: 初めから習得
+  StartTime: 2022-12-31T15:00:00Z
+  EndTime: 2035-12-31T14:59:00Z
+  MaxAp: 20
   IsVideoMode: 0
   VideoBgId: 0
   SongType: 1
-  MusicScoreReleaseTime: 2025-11-20T12:00:00Z
+  MusicScoreReleaseTime: 2025-11-30T03:00:00Z
+- Id: 405127
+  OrderId: 1631
+  Title: Hip, hip, hooray!
+  TitleFurigana: ひっぷひっぷふーれい
+  JacketId: 405127
+  SoundId: 40512701
+  Description: みらくらぱーく！
+  GenerationsId: 105
+  UnitId: 103
+  CenterCharacterId: 1033
+  SingerCharacterId: "1043"
+  SupportCharacterId: 1031,1032,1041,1042,1051,1052
+  MusicType: 2
+  ExperienceType: 1
+  BeatPointCoefficient: 10588
+  ApIncrement: 1040
+  SongTime: 10400
+  PlayTime: 124800
+  FeverSectionNo: 5
+  PreviewStartTime: 10000
+  PreviewEndTime: 15000
+  PreviewFadeInTime: 11000
+  PreviewFadeOutTime: 14000
+  ReleaseConditionType: 0
+  ReleaseConditionDetail: 0
+  ReleaseConditionText: 初めから習得
+  StartTime: 2022-12-31T15:00:00Z
+  EndTime: 2035-12-31T14:59:00Z
+  MaxAp: 20
+  IsVideoMode: 0
+  VideoBgId: 0
+  SongType: 1
+  MusicScoreReleaseTime: 2025-12-10T01:00:00Z
+- Id: 405128
+  OrderId: 1810
+  Title: 令嬢モブ！
+  TitleFurigana: れいじょうもぶ
+  JacketId: 405128
+  SoundId: 40512801
+  Description: Edel Note
+  GenerationsId: 105
+  UnitId: 105
+  CenterCharacterId: 1052
+  SingerCharacterId: "1051"
+  SupportCharacterId: 1031,1032,1033,1041,1042,1043
+  MusicType: 3
+  ExperienceType: 1
+  BeatPointCoefficient: 11392
+  ApIncrement: 1131
+  SongTime: 11311
+  PlayTime: 135726
+  FeverSectionNo: 5
+  PreviewStartTime: 10000
+  PreviewEndTime: 15000
+  PreviewFadeInTime: 11000
+  PreviewFadeOutTime: 14000
+  ReleaseConditionType: 0
+  ReleaseConditionDetail: 0
+  ReleaseConditionText: 初めから習得
+  StartTime: 2022-12-31T15:00:00Z
+  EndTime: 2035-12-31T14:59:00Z
+  MaxAp: 20
+  IsVideoMode: 0
+  VideoBgId: 0
+  SongType: 1
+  MusicScoreReleaseTime: 2025-12-19T03:00:00Z
+- Id: 405129
+  OrderId: 1042
+  Title: 雪舞う空と二秒の永遠
+  TitleFurigana: ゆきまうそらとにびょうのえいえん
+  JacketId: 405129
+  SoundId: 40512901
+  Description: 全体曲
+  GenerationsId: 105
+  UnitId: 100
+  CenterCharacterId: 1031
+  SingerCharacterId: 1032,1033,1041,1042,1043,1051,1052
+  SupportCharacterId: "0"
+  MusicType: 1
+  ExperienceType: 1
+  BeatPointCoefficient: 33333
+  ApIncrement: 1000
+  SongTime: 10000
+  PlayTime: 120000
+  FeverSectionNo: 5
+  PreviewStartTime: 10000
+  PreviewEndTime: 15000
+  PreviewFadeInTime: 11000
+  PreviewFadeOutTime: 14000
+  ReleaseConditionType: 0
+  ReleaseConditionDetail: 0
+  ReleaseConditionText: 初めから習得
+  StartTime: 2022-12-31T15:00:00Z
+  EndTime: 2035-12-31T14:59:00Z
+  MaxAp: 20
+  IsVideoMode: 0
+  VideoBgId: 0
+  SongType: 1
+  MusicScoreReleaseTime: 2025-12-28T12:00:00Z
+- Id: 405130
+  OrderId: 1235
+  Title: Sayo-Shigure
+  TitleFurigana: さよしぐれ
+  JacketId: 405130
+  SoundId: 40513001
+  Description: スリーズブーケ
+  GenerationsId: 105
+  UnitId: 101
+  CenterCharacterId: 1031
+  SingerCharacterId: "1041"
+  SupportCharacterId: 1032,1033,1042,1043,1051,1052
+  MusicType: 2
+  ExperienceType: 1
+  BeatPointCoefficient: 15254
+  ApIncrement: 823
+  SongTime: 8228
+  PlayTime: 98734
+  FeverSectionNo: 4
+  PreviewStartTime: 10000
+  PreviewEndTime: 15000
+  PreviewFadeInTime: 11000
+  PreviewFadeOutTime: 14000
+  ReleaseConditionType: 0
+  ReleaseConditionDetail: 0
+  ReleaseConditionText: 初めから習得
+  StartTime: 2022-12-31T15:00:00Z
+  EndTime: 2035-12-31T14:59:00Z
+  MaxAp: 20
+  IsVideoMode: 0
+  VideoBgId: 0
+  SongType: 1
+  MusicScoreReleaseTime: 2026-01-11T03:00:00Z
+- Id: 405131
+  OrderId: 3005
+  Title: ハロめぐ讃歌
+  TitleFurigana: はろめぐさんか
+  JacketId: 405131
+  SoundId: 40513101
+  Description: ソロ曲
+  GenerationsId: 1053
+  UnitId: 103
+  CenterCharacterId: 1023
+  SingerCharacterId: "0"
+  SupportCharacterId: 1031,1032,1033,1041,1042,1043,1051,1052
+  MusicType: 1
+  ExperienceType: 1
+  BeatPointCoefficient: 10465
+  ApIncrement: 1011
+  SongTime: 10110
+  PlayTime: 121319
+  FeverSectionNo: 4
+  PreviewStartTime: 10000
+  PreviewEndTime: 15000
+  PreviewFadeInTime: 11000
+  PreviewFadeOutTime: 14000
+  ReleaseConditionType: 0
+  ReleaseConditionDetail: 0
+  ReleaseConditionText: 初めから習得
+  StartTime: 2022-12-31T15:00:00Z
+  EndTime: 2035-12-31T14:59:00Z
+  MaxAp: 20
+  IsVideoMode: 0
+  VideoBgId: 0
+  SongType: 1
+  MusicScoreReleaseTime: 2026-01-11T03:00:00Z
+- Id: 405201
+  OrderId: 6033
+  Title: テレパシ
+  TitleFurigana: てれぱし
+  JacketId: 405201
+  SoundId: 40520101
+  Description: 一般カバー
+  GenerationsId: 105
+  UnitId: 103
+  CenterCharacterId: 1043
+  SingerCharacterId: "1033"
+  SupportCharacterId: 1031,1032,1041,1042,1051,1052
+  MusicType: 2
+  ExperienceType: 1
+  BeatPointCoefficient: 7895
+  ApIncrement: 1171
+  SongTime: 11707
+  PlayTime: 140488
+  FeverSectionNo: 5
+  PreviewStartTime: 10000
+  PreviewEndTime: 15000
+  PreviewFadeInTime: 11000
+  PreviewFadeOutTime: 14000
+  ReleaseConditionType: 2
+  ReleaseConditionDetail: 1
+  ReleaseConditionText: ミュージックPt. を使用して習得
+  StartTime: 2022-12-31T15:00:00Z
+  EndTime: 2035-12-31T14:59:00Z
+  MaxAp: 20
+  IsVideoMode: 0
+  VideoBgId: 0
+  SongType: 2
+  MusicScoreReleaseTime: 2025-11-30T03:00:00Z
+- Id: 405202
+  OrderId: 6034
+  Title: BOW AND ARROW
+  TitleFurigana: ぼうあんどあろう
+  JacketId: 405202
+  SoundId: 40520201
+  Description: 一般カバー
+  GenerationsId: 105
+  UnitId: 102
+  CenterCharacterId: 1032
+  SingerCharacterId: "1042"
+  SupportCharacterId: 1031,1033,1041,1043,1051,1052
+  MusicType: 3
+  ExperienceType: 1
+  BeatPointCoefficient: 14286
+  ApIncrement: 767
+  SongTime: 7667
+  PlayTime: 92000
+  FeverSectionNo: 4
+  PreviewStartTime: 10000
+  PreviewEndTime: 15000
+  PreviewFadeInTime: 11000
+  PreviewFadeOutTime: 14000
+  ReleaseConditionType: 2
+  ReleaseConditionDetail: 1
+  ReleaseConditionText: ミュージックPt. を使用して習得
+  StartTime: 2022-12-31T15:00:00Z
+  EndTime: 2035-12-31T14:59:00Z
+  MaxAp: 20
+  IsVideoMode: 0
+  VideoBgId: 0
+  SongType: 2
+  MusicScoreReleaseTime: 2025-12-19T03:00:00Z
+- Id: 405203
+  OrderId: 6035
+  Title: もういちど ルミナス
+  TitleFurigana: もういちどるみなす
+  JacketId: 405203
+  SoundId: 40520301
+  Description: 一般カバー
+  GenerationsId: 105
+  UnitId: 101
+  CenterCharacterId: 1041
+  SingerCharacterId: "1031"
+  SupportCharacterId: 1032,1033,1042,1043,1051,1052
+  MusicType: 2
+  ExperienceType: 1
+  BeatPointCoefficient: 11842
+  ApIncrement: 970
+  SongTime: 9704
+  PlayTime: 116450
+  FeverSectionNo: 4
+  PreviewStartTime: 10000
+  PreviewEndTime: 15000
+  PreviewFadeInTime: 11000
+  PreviewFadeOutTime: 14000
+  ReleaseConditionType: 2
+  ReleaseConditionDetail: 1
+  ReleaseConditionText: ミュージックPt. を使用して習得
+  StartTime: 2022-12-31T15:00:00Z
+  EndTime: 2035-12-31T14:59:00Z
+  MaxAp: 20
+  IsVideoMode: 0
+  VideoBgId: 0
+  SongType: 2
+  MusicScoreReleaseTime: 2026-01-05T03:00:00Z
+- Id: 405204
+  OrderId: 6036
+  Title: 壱雫空
+  TitleFurigana: ひとしずく
+  JacketId: 405204
+  SoundId: 40520401
+  Description: 一般カバー
+  GenerationsId: 105
+  UnitId: 102
+  CenterCharacterId: 1042
+  SingerCharacterId: "1032"
+  SupportCharacterId: 1031,1033,1041,1043,1051,1052
+  MusicType: 3
+  ExperienceType: 1
+  BeatPointCoefficient: 12500
+  ApIncrement: 765
+  SongTime: 7647
+  PlayTime: 91765
+  FeverSectionNo: 4
+  PreviewStartTime: 10000
+  PreviewEndTime: 15000
+  PreviewFadeInTime: 11000
+  PreviewFadeOutTime: 14000
+  ReleaseConditionType: 2
+  ReleaseConditionDetail: 1
+  ReleaseConditionText: ミュージックPt. を使用して習得
+  StartTime: 2022-12-31T15:00:00Z
+  EndTime: 2035-12-31T14:59:00Z
+  MaxAp: 20
+  IsVideoMode: 0
+  VideoBgId: 0
+  SongType: 2
+  MusicScoreReleaseTime: 2026-01-05T03:00:00Z
+- Id: 405205
+  OrderId: 6037
+  Title: キミがいなくちゃっ！
+  TitleFurigana: きみがいなくちゃっ
+  JacketId: 405205
+  SoundId: 40520501
+  Description: 一般カバー
+  GenerationsId: 105
+  UnitId: 103
+  CenterCharacterId: 1043
+  SingerCharacterId: "1033"
+  SupportCharacterId: 1031,1032,1041,1042,1051,1052
+  MusicType: 1
+  ExperienceType: 1
+  BeatPointCoefficient: 18750
+  ApIncrement: 871
+  SongTime: 8710
+  PlayTime: 104516
+  FeverSectionNo: 5
+  PreviewStartTime: 10000
+  PreviewEndTime: 15000
+  PreviewFadeInTime: 11000
+  PreviewFadeOutTime: 14000
+  ReleaseConditionType: 2
+  ReleaseConditionDetail: 1
+  ReleaseConditionText: ミュージックPt. を使用して習得
+  StartTime: 2022-12-31T15:00:00Z
+  EndTime: 2035-12-31T14:59:00Z
+  MaxAp: 20
+  IsVideoMode: 0
+  VideoBgId: 0
+  SongType: 2
+  MusicScoreReleaseTime: 2026-01-05T03:00:00Z
+- Id: 405206
+  OrderId: 6038
+  Title: FIRE BIRD
+  TitleFurigana: ふぁいあばーど
+  JacketId: 405206
+  SoundId: 40520601
+  Description: 一般カバー
+  GenerationsId: 105
+  UnitId: 105
+  CenterCharacterId: 1051
+  SingerCharacterId: "1052"
+  SupportCharacterId: 1031,1032,1033,1041,1042,1043
+  MusicType: 3
+  ExperienceType: 1
+  BeatPointCoefficient: 13846
+  ApIncrement: 1096
+  SongTime: 10956
+  PlayTime: 131470
+  FeverSectionNo: 5
+  PreviewStartTime: 10000
+  PreviewEndTime: 15000
+  PreviewFadeInTime: 11000
+  PreviewFadeOutTime: 14000
+  ReleaseConditionType: 2
+  ReleaseConditionDetail: 1
+  ReleaseConditionText: ミュージックPt. を使用して習得
+  StartTime: 2022-12-31T15:00:00Z
+  EndTime: 2035-12-31T14:59:00Z
+  MaxAp: 20
+  IsVideoMode: 0
+  VideoBgId: 0
+  SongType: 2
+  MusicScoreReleaseTime: 2026-01-05T03:00:00Z
 - Id: 405301
   OrderId: 5011
   Title: 虹色Passions!

--- a/MainBatch.py
+++ b/MainBatch.py
@@ -635,6 +635,16 @@ if __name__ == "__main__":
         mustcards_all = song_config["mustcards_all"]
         mustcards_any = song_config["mustcards_any"]
         banned_cards = song_config.get("banned_cards", [])  # 獲取禁卡列表，預設為空
+
+        # 好友卡池：優先使用該首歌專用的，否則使用全局的
+        song_friend_card_pool = song_config.get("friend_card_pool", [])
+        if song_friend_card_pool:
+            friend_card_pool = song_friend_card_pool
+        elif use_yaml_config and yaml_config:
+            friend_card_pool = yaml_config.config.get("friend_card_ids", [])
+        else:
+            friend_card_pool = []
+
         center_override = song_config.get("center_override", None)
         color_override = song_config.get("color_override", None)
         mastery_level = song_config["mastery_level"]
@@ -825,7 +835,8 @@ if __name__ == "__main__":
             force_dr=force_dr,
             log_path=os.path.join(FINAL_OUTPUT_DIR, f"simulation_results_{fixed_music_id}_{fixed_difficulty}.json"),
             allow_double_cards=allow_double_cards,
-            banned_cards=banned_cards
+            banned_cards=banned_cards,
+            friend_card=friend_card_pool
         )
         total_decks_to_simulate = decks_generator.total_decks
         logger.info(f"{total_decks_to_simulate} decks to be simulated.")

--- a/MainBatch.py
+++ b/MainBatch.py
@@ -559,6 +559,10 @@ if __name__ == "__main__":
             logger.info("未找到 YAML 配置，使用舊方法（CardLevelConfig.py）")
             pass
 
+    # 保存 debug 模式標記（如果有）
+    is_debug_mode = isinstance(SONGS_CONFIG, dict) and SONGS_CONFIG.get("debug_mode")
+    debug_mode_config = SONGS_CONFIG if is_debug_mode else None
+
     # 如果使用 YAML 配置，載入相關設定
     if use_yaml_config and yaml_config:
         yaml_config.print_summary()
@@ -572,25 +576,28 @@ if __name__ == "__main__":
         custom_card_levels = yaml_config.get_card_levels()  # 讀取自定義卡牌練度
         if custom_card_levels:
             logger.info(f"載入了 {len(custom_card_levels)} 張卡牌的自定義練度")
-        SONGS_CONFIG = None  # 重置為 None，讓後面使用 UNIFIED_CONFIG
+
+        # 如果不是 debug 模式，重置 SONGS_CONFIG
+        if not is_debug_mode:
+            SONGS_CONFIG = None  # 重置為 None，讓後面使用 UNIFIED_CONFIG
 
     # 如果是 Debug 模式，直接運行並退出
-    if isinstance(SONGS_CONFIG, dict) and SONGS_CONFIG.get("debug_mode"):
+    if is_debug_mode and debug_mode_config:
         # 建立歌曲配置字典（只包含有值的參數）
         debug_song_config = {}
-        if "music_id" in SONGS_CONFIG:
-            debug_song_config["music_id"] = SONGS_CONFIG["music_id"]
-        if "difficulty" in SONGS_CONFIG:
-            debug_song_config["difficulty"] = SONGS_CONFIG["difficulty"]
-        if "mastery_level" in SONGS_CONFIG:
-            debug_song_config["mastery_level"] = SONGS_CONFIG["mastery_level"]
+        if "music_id" in debug_mode_config:
+            debug_song_config["music_id"] = debug_mode_config["music_id"]
+        if "difficulty" in debug_mode_config:
+            debug_song_config["difficulty"] = debug_mode_config["difficulty"]
+        if "mastery_level" in debug_mode_config:
+            debug_song_config["mastery_level"] = debug_mode_config["mastery_level"]
 
         run_debug_mode(
-            SONGS_CONFIG["deck_cards"],
-            SONGS_CONFIG["center_index"],
+            debug_mode_config["deck_cards"],
+            debug_mode_config["center_index"],
             UNIFIED_CONFIG,
             custom_card_levels,
-            SONGS_CONFIG.get("friend_card"),
+            debug_mode_config.get("friend_card"),
             debug_song_config if debug_song_config else None
         )
         end_time = time.time()

--- a/MainBatch.py
+++ b/MainBatch.py
@@ -588,6 +588,7 @@ if __name__ == "__main__":
         fixed_difficulty = song_config["difficulty"]
         mustcards_all = song_config["mustcards_all"]
         mustcards_any = song_config["mustcards_any"]
+        banned_cards = song_config.get("banned_cards", [])  # 獲取禁卡列表，預設為空
         center_override = song_config["center_override"]
         color_override = song_config["color_override"]
         mastery_level = song_config["mastery_level"]
@@ -777,7 +778,8 @@ if __name__ == "__main__":
             center_char=pre_initialized_chart.music.CenterCharacterId,
             force_dr=force_dr,
             log_path=os.path.join(FINAL_OUTPUT_DIR, f"simulation_results_{fixed_music_id}_{fixed_difficulty}.json"),
-            allow_double_cards=allow_double_cards
+            allow_double_cards=allow_double_cards,
+            banned_cards=banned_cards
         )
         total_decks_to_simulate = decks_generator.total_decks
         logger.info(f"{total_decks_to_simulate} decks to be simulated.")

--- a/MainBatch.py
+++ b/MainBatch.py
@@ -179,15 +179,6 @@ def parse_arguments(unified_config):
 
     args = parser.parse_args()
 
-    # 如果提供了 --config 參數，從 YAML 載入配置
-    if args.config:
-        if not CONFIG_MANAGER_AVAILABLE:
-            logger.error("錯誤：config_manager.py 不可用，無法使用 --config 參數")
-            logger.error("請確保 config_manager.py 存在於專案目錄中")
-            sys.exit(1)
-        return {"use_yaml_config": True, "config_file": args.config}
-
-
     # 如果是 Debug 模式，返回特殊標記
     if args.debug is not None:
         # 如果指定了卡牌，使用指定的；否則使用配置中的
@@ -225,7 +216,24 @@ def parse_arguments(unified_config):
         if args.mastery:
             debug_config["mastery_level"] = args.mastery
 
+        # 如果提供了 --config 參數，加入配置檔案路徑
+        if args.config:
+            if not CONFIG_MANAGER_AVAILABLE:
+                logger.error("錯誤：config_manager.py 不可用，無法使用 --config 參數")
+                logger.error("請確保 config_manager.py 存在於專案目錄中")
+                sys.exit(1)
+            debug_config["use_yaml_config"] = True
+            debug_config["config_file"] = args.config
+
         return debug_config
+
+    # 如果提供了 --config 但沒有其他參數，從 YAML 載入配置
+    if args.config:
+        if not CONFIG_MANAGER_AVAILABLE:
+            logger.error("錯誤：config_manager.py 不可用，無法使用 --config 參數")
+            logger.error("請確保 config_manager.py 存在於專案目錄中")
+            sys.exit(1)
+        return {"use_yaml_config": True, "config_file": args.config}
 
     # 如果沒有命令列參數，使用預設配置
     if not args.songs:
@@ -282,8 +290,8 @@ def run_debug_mode(deck_cards, center_index, config, custom_card_levels=None, fr
     fixed_music_id = debug_song_config.get("music_id") if debug_song_config and "music_id" in debug_song_config else first_song["music_id"]
     fixed_difficulty = debug_song_config.get("difficulty") if debug_song_config and "difficulty" in debug_song_config else first_song["difficulty"]
     fixed_player_master_level = debug_song_config.get("mastery_level") if debug_song_config and "mastery_level" in debug_song_config else first_song["mastery_level"]
-    center_override = first_song.get("center_override")
-    color_override = first_song.get("color_override")
+    center_override = first_song.get("center_override", None)
+    color_override = first_song.get("color_override", None)
 
     logger.info(f"\n牌組卡片ID: {deck_cards}")
     if friend_card:
@@ -412,7 +420,7 @@ if __name__ == "__main__":
         # 可以配置一首或多首歌曲，程式會自動判斷
         "songs": [
             {
-                "music_id": "405117",        # 歌曲ID
+                "music_id": "405120",        # 歌曲ID
                 "difficulty": "02",          # 難度 (01=Normal, 02=Hard, 03=Expert, 04=Master)
                 "mastery_level": 50,         # 熟練度 (1-50)
                 "mustcards_all": [],         # [#1032528, 1032530, 1031530],  # 必須包含的所有卡牌
@@ -618,8 +626,8 @@ if __name__ == "__main__":
         mustcards_all = song_config["mustcards_all"]
         mustcards_any = song_config["mustcards_any"]
         banned_cards = song_config.get("banned_cards", [])  # 獲取禁卡列表，預設為空
-        center_override = song_config["center_override"]
-        color_override = song_config["color_override"]
+        center_override = song_config.get("center_override", None)
+        color_override = song_config.get("color_override", None)
         mastery_level = song_config["mastery_level"]
         leader_designation = song_config["leader_designation"]
 

--- a/MainBatch.py
+++ b/MainBatch.py
@@ -96,6 +96,7 @@ def save_simulation_results(results_data: list, filename: str = os.path.join("lo
         current_deck_card_ids = result['deck_card_ids']
         current_score = result['score']
         center_card = result['center_card']
+        friend_card = result.get('friend_card')
 
         # Create a standardized key for comparison (sorted tuple of card IDs)
         # Ensure card IDs are integers for consistent sorting if they are not already
@@ -108,6 +109,7 @@ def save_simulation_results(results_data: list, filename: str = os.path.join("lo
                 'deck_card_ids': current_deck_card_ids,
                 'center_card': center_card,
                 'score': current_score,
+                'friend_card': friend_card,
             }
 
     # Convert the unique decks dictionary back to a list of results

--- a/config/default-example.yaml
+++ b/config/default-example.yaml
@@ -14,6 +14,7 @@ songs:
     mastery_level: 50
     mustcards_all: []          # 必須包含的卡牌 (全部)
     mustcards_any: []          # 必須包含的卡牌 (任一)
+    banned_cards: []           # 禁止使用的卡牌 (模擬時不會加入卡組)
     center_override: null      # 覆蓋 Center 位置 (null 表示不覆蓋)
     color_override: null       # 覆蓋顏色 (null 表示不覆蓋)
     leader_designation: "0"    # 隊長指定 (0-9 或字串 card_id)
@@ -23,6 +24,7 @@ songs:
     mastery_level: 50
     mustcards_all: []
     mustcards_any: []
+    banned_cards: []
     center_override: null
     color_override: null
     leader_designation: "0"
@@ -32,6 +34,7 @@ songs:
     mastery_level: 50
     mustcards_all: []
     mustcards_any: []
+    banned_cards: []
     center_override: null
     color_override: null
     leader_designation: "0"
@@ -132,5 +135,20 @@ cache:
 optimizer:
   top_n: 50000                 # 每首歌保留得分排名前 N 名的卡組
   show_card_names: true        # 在輸出中顯示卡牌名稱
-  forbidden_cards: []          # 禁止使用的卡牌 ID 列表 (三面均生效)
+  forbidden_cards: []          # 全局禁止使用的卡牌 ID 列表 (三面均生效)
                                # 範例: [1011501, 1052506]  # 禁用特定卡牌
+
+  # 多曲優化器歌曲配置 (可選，優先級高於上方的 songs 配置)
+  # 如果配置了此區塊，優化器將使用這裡的歌曲列表和禁卡設定
+  # songs:
+  #   - music_id: "405117"
+  #     difficulty: "02"
+  #     banned_cards: []       # 該首歌的禁卡 (與全局禁卡合併使用)
+  #
+  #   - music_id: "405118"
+  #     difficulty: "02"
+  #     banned_cards: []
+  #
+  #   - music_id: "405305"
+  #     difficulty: "02"
+  #     banned_cards: []

--- a/config/default-example.yaml
+++ b/config/default-example.yaml
@@ -12,6 +12,7 @@ songs:
   - music_id: "405117"
     difficulty: "02"
     mastery_level: 50
+    friend_card_pool: []       # 該首歌專用的朋友卡池 (覆蓋全局配置)
     mustcards_all: []          # 必須包含的卡牌 (全部)
     mustcards_any: []          # 必須包含的卡牌 (任一)
     banned_cards: []           # 禁止使用的卡牌 (模擬時不會加入卡組)
@@ -47,6 +48,10 @@ debug_deck_cards:
   - 1051506
   - 1021701
   - 1041802
+
+# 全局朋友卡片池 (預設可用的朋友卡片)
+# 朋友卡片固定為滿練度，且不能是 DR 卡或與卡組重複
+friend_card_ids: []
 
 # 卡牌池配置
 card_ids:

--- a/config/member-example.yaml
+++ b/config/member-example.yaml
@@ -15,6 +15,13 @@ songs:
     friend_card_pool: []       # 該首歌專用的朋友卡池 (覆蓋全局配置)
     mustcards_all: []
     mustcards_any: []
+    mustskills: [2, 3, 5, 7, 8]  # 必須包含的技能類型（可選）
+                               # 2=分卡, 3=電, 5=洗牌/DR, 7=分加成, 8=電加成
+                               # 範例: [2, 3, 7, 8] = 分卡+電+分加成+電加成（不強制 DR）
+                               # 留空 [] 則不檢查必要技能
+    secondary_center: []       # 次要中心角色（可選的額外中心卡）
+                               # 用於指定非高稀有度但想作為中心卡的特定卡片
+                               # 範例: [1031533, 1032530, 1033528]
     banned_cards: []           # 禁止使用的卡牌 (模擬時不會加入卡組)
                                # 範例: [1011501, 1052506]  # 禁用特定卡牌
     center_override: null
@@ -27,6 +34,8 @@ songs:
     friend_card_pool: []       # 該首歌專用的朋友卡池 (覆蓋全局配置)
     mustcards_all: []
     mustcards_any: []
+    mustskills: [2, 3, 5, 7, 8]
+    secondary_center: []
     banned_cards: []
     center_override: null
     color_override: null
@@ -38,6 +47,8 @@ songs:
     friend_card_pool: []       # 該首歌專用的朋友卡池 (覆蓋全局配置)
     mustcards_all: []
     mustcards_any: []
+    mustskills: [2, 3, 5, 7, 8]
+    secondary_center: []
     banned_cards: []
     center_override: null
     color_override: null

--- a/config/member-example.yaml
+++ b/config/member-example.yaml
@@ -14,6 +14,8 @@ songs:
     mastery_level: 50
     mustcards_all: []
     mustcards_any: []
+    banned_cards: []           # 禁止使用的卡牌 (模擬時不會加入卡組)
+                               # 範例: [1011501, 1052506]  # 禁用特定卡牌
     center_override: null
     color_override: null
     leader_designation: "0"
@@ -23,6 +25,7 @@ songs:
     mastery_level: 50
     mustcards_all: []
     mustcards_any: []
+    banned_cards: []
     center_override: null
     color_override: null
     leader_designation: "0"
@@ -32,6 +35,7 @@ songs:
     mastery_level: 50
     mustcards_all: []
     mustcards_any: []
+    banned_cards: []
     center_override: null
     color_override: null
     leader_designation: "0"
@@ -119,3 +123,25 @@ cache:
   max_fingerprints_in_memory: 5000000
   auto_cleanup: true
   max_cache_age_days: 7
+
+# 優化器配置 (用於 multi_optimizer_2.py)
+optimizer:
+  top_n: 50000                 # 每首歌保留得分排名前 N 名的卡組
+  show_card_names: true        # 在輸出中顯示卡牌名稱
+  forbidden_cards: []          # 全局禁止使用的卡牌 ID 列表 (三面均生效)
+                               # 範例: [1011501, 1052506]  # 禁用特定卡牌
+
+  # 多曲優化器歌曲配置 (可選，優先級高於上方的 songs 配置)
+  # 如果配置了此區塊，優化器將使用這裡的歌曲列表和禁卡設定
+  # songs:
+  #   - music_id: "405117"
+  #     difficulty: "02"
+  #     banned_cards: []       # 該首歌的禁卡 (與全局禁卡合併使用)
+  #
+  #   - music_id: "405118"
+  #     difficulty: "03"
+  #     banned_cards: []
+  #
+  #   - music_id: "405305"
+  #     difficulty: "04"
+  #     banned_cards: []

--- a/config/member-example.yaml
+++ b/config/member-example.yaml
@@ -12,6 +12,7 @@ songs:
   - music_id: "405117"
     difficulty: "02"           # 01=Normal, 02=Hard, 03=Expert, 04=Master
     mastery_level: 50
+    friend_card_pool: []       # 該首歌專用的朋友卡池 (覆蓋全局配置)
     mustcards_all: []
     mustcards_any: []
     banned_cards: []           # 禁止使用的卡牌 (模擬時不會加入卡組)
@@ -23,6 +24,7 @@ songs:
   - music_id: "405118"
     difficulty: "03"           # Expert
     mastery_level: 50
+    friend_card_pool: []       # 該首歌專用的朋友卡池 (覆蓋全局配置)
     mustcards_all: []
     mustcards_any: []
     banned_cards: []
@@ -33,6 +35,7 @@ songs:
   - music_id: "405305"
     difficulty: "04"           # Master
     mastery_level: 50
+    friend_card_pool: []       # 該首歌專用的朋友卡池 (覆蓋全局配置)
     mustcards_all: []
     mustcards_any: []
     banned_cards: []
@@ -42,6 +45,11 @@ songs:
 
 # Debug 卡組 (可選，用於單卡組測試)
 debug_deck_cards: null
+
+# 全局朋友卡片池 (預設可用的朋友卡片)
+friend_card_ids:
+  - 1011501
+  - 1021701
 
 # Alice 的卡池
 card_ids:

--- a/multi_optimizer_2.py
+++ b/multi_optimizer_2.py
@@ -263,7 +263,9 @@ if __name__ == "__main__":
                 "rank": i,
                 "score": deck["score"],
                 "pt": deck["pt"],
-                "deck": deck["deck_card_ids"]
+                "deck": deck["deck_card_ids"],
+                "friend_card": deck.get("friend_card"),
+                "center_card": deck.get("center_card")
             })
         levels.append(decks)
 
@@ -404,8 +406,22 @@ if __name__ == "__main__":
                 output.append(f"  Score: {d['score']:,}")
                 output.append(f"  Pt: {d['pt']:,}  (Rank: #{d['rank']})")
                 output.append(f"  Deck:")
+                
+                # 顯示隊長（如果有）
+                if d.get('center_card'):
+                    cc_id = d['center_card']
+                    cc_char, cc_name = get_card_full_info(cc_id)
+                    output.append(f"    Leader: {cc_id}: {cc_char} - {cc_name}")
+
                 # 使用新的格式化函數顯示卡組
                 output.append(format_deck_with_names(d['deck']))
+                
+                # 顯示朋友卡片（如果有）
+                if d.get('friend_card'):
+                    fc_id = d['friend_card']
+                    fc_char, fc_name = get_card_full_info(fc_id)
+                    output.append(f"  Friend Card: {fc_id}: {fc_char} - {fc_name}")
+                
                 output.append("")
 
         output = "\n".join(output)

--- a/multi_optimizer_2.py
+++ b/multi_optimizer_2.py
@@ -23,9 +23,9 @@ logging.basicConfig(
 # 求解前需运行 MainBatch.py 生成对应的卡组得分记录
 CHALLENGE_SONGS = [
     # 若只输入两首歌则会寻找仅针对两面的最优解，不考虑第三面
-    ("405119", "02"),  # 一生に夢が咲くように
-    ("405121", "02"),  # ハートにQ
-    ("405107", "02"),  # Shocking Party
+    ("405126", "02"),  # 一生に夢が咲くように
+    ("405128", "02"),  # ハートにQ
+    ("405120", "02"),  # Shocking Party
 ]
 
 # 每首歌只保留得分排名前 N 名的卡组用于求解
@@ -118,6 +118,8 @@ if __name__ == "__main__":
     start_time = time.time()
 
     # 嘗試讀取配置管理器以獲取正確的 log 目錄和優化器設定
+    song_banned_cards = {}  # 每首歌的禁卡字典: {(music_id, difficulty): [banned_card_ids]}
+
     try:
         from src.config.config_manager import get_config
         if args.config:
@@ -137,8 +139,36 @@ if __name__ == "__main__":
         SHOWNAME = config.get_optimizer_show_names()
         FORBIDDEN_CARD = config.get_forbidden_cards()
 
+        # 優先使用 optimizer.songs 配置，如果沒有則使用主 songs 配置
+        optimizer_songs = config.get_optimizer_songs()
+        if optimizer_songs:
+            # 使用優化器專屬的歌曲配置
+            CHALLENGE_SONGS = [(s["music_id"], s["difficulty"]) for s in optimizer_songs]
+            for song in optimizer_songs:
+                music_id = song.get("music_id")
+                difficulty = song.get("difficulty")
+                banned_cards = song.get("banned_cards", [])
+                if music_id and difficulty:
+                    song_banned_cards[(music_id, difficulty)] = banned_cards
+            logger.info(f"使用優化器專屬歌曲配置: {len(optimizer_songs)} 首歌")
+        else:
+            # 使用主 songs 配置讀取每首歌的禁卡
+            songs_config = config.get_songs_config()
+            for song in songs_config:
+                music_id = song.get("music_id")
+                difficulty = song.get("difficulty")
+                banned_cards = song.get("banned_cards", [])
+                if music_id and difficulty:
+                    song_banned_cards[(music_id, difficulty)] = banned_cards
+            logger.info(f"使用主 songs 配置中的禁卡設定")
+
         logger.info(f"優化器配置: TOP_N={TOP_N}, SHOWNAME={SHOWNAME}, "
-                   f"FORBIDDEN_CARD={FORBIDDEN_CARD if FORBIDDEN_CARD else '[]'}")
+                   f"FORBIDDEN_CARD(全局)={FORBIDDEN_CARD if FORBIDDEN_CARD else '[]'}")
+        if song_banned_cards:
+            logger.info(f"每首歌的禁卡配置:")
+            for (mid, diff), banned in song_banned_cards.items():
+                if banned:
+                    logger.info(f"  {mid}_{diff}: {banned}")
 
     except (ImportError, ValueError, FileNotFoundError) as e:
         # 如果沒有配置管理器或找不到配置，使用默認的 log 目錄和全局常量
@@ -161,20 +191,28 @@ if __name__ == "__main__":
             data = json.load(fh)
             total = len(data)
             data.sort(key=lambda x: x["pt"], reverse=True)
-            
+
+            song_id, difficulty = CHALLENGE_SONGS[i]
+
+            # 合併全局禁卡和該首歌的禁卡
+            combined_forbidden = set(FORBIDDEN_CARD) if FORBIDDEN_CARD else set()
+            song_specific_banned = song_banned_cards.get((song_id, difficulty), [])
+            if song_specific_banned:
+                combined_forbidden.update(song_specific_banned)
+
             # 在切片前先過濾禁卡，確保 TOP_N 是有效的卡組
-            if FORBIDDEN_CARD:
+            if combined_forbidden:
                 original_count = len(data)
-                data = [d for d in data if not any(cid in d["deck_card_ids"] for cid in FORBIDDEN_CARD)]
+                data = [d for d in data if not any(cid in d["deck_card_ids"] for cid in combined_forbidden)]
                 filtered_count = len(data)
                 if original_count != filtered_count:
-                    logger.info(f"  Filtered {original_count - filtered_count} decks containing forbidden cards")
+                    logger.info(f"  {song_id}_{difficulty}: 過濾了 {original_count - filtered_count} 個包含禁卡的卡組")
 
             data = data[:TOP_N]
             levels_raw.append(data)
             for deck in data:
                 all_cards.update(deck["deck_card_ids"])
-        song_id, difficulty = CHALLENGE_SONGS[i]
+
         song_title = get_song_title(song_id)
         logger.info(f"Loaded top {TOP_N} of {total} results for {song_id}_{difficulty} ({song_title})")
 

--- a/multi_optimizer_2.py
+++ b/multi_optimizer_2.py
@@ -152,15 +152,16 @@ if __name__ == "__main__":
                     song_banned_cards[(music_id, difficulty)] = banned_cards
             logger.info(f"使用優化器專屬歌曲配置: {len(optimizer_songs)} 首歌")
         else:
-            # 使用主 songs 配置讀取每首歌的禁卡
+            # 使用主 songs 配置讀取歌曲列表和禁卡
             songs_config = config.get_songs_config()
+            CHALLENGE_SONGS = [(s["music_id"], s["difficulty"]) for s in songs_config]
             for song in songs_config:
                 music_id = song.get("music_id")
                 difficulty = song.get("difficulty")
                 banned_cards = song.get("banned_cards", [])
                 if music_id and difficulty:
                     song_banned_cards[(music_id, difficulty)] = banned_cards
-            logger.info(f"使用主 songs 配置中的禁卡設定")
+            logger.info(f"使用主 songs 配置: {len(songs_config)} 首歌")
 
         logger.info(f"優化器配置: TOP_N={TOP_N}, SHOWNAME={SHOWNAME}, "
                    f"FORBIDDEN_CARD(全局)={FORBIDDEN_CARD if FORBIDDEN_CARD else '[]'}")

--- a/src/config/CardLevelConfig.py
+++ b/src/config/CardLevelConfig.py
@@ -47,6 +47,7 @@ CARD_CACHE: dict[int, list[int]] = {
 DEATH_NOTE: dict[int, int] = {
     1041513: 10,  # 宴会吟
     1041901: 25,  # BR吟
+    1041902: 10,  # BR2吟
 }
 
 

--- a/src/config/config_manager.py
+++ b/src/config/config_manager.py
@@ -268,6 +268,19 @@ class ConfigManager:
         """
         return self.get_optimizer_config()["show_card_names"]
 
+    def get_optimizer_songs(self) -> List[Dict[str, Any]]:
+        """
+        獲取優化器的歌曲配置列表
+
+        如果 optimizer.songs 存在，使用該配置
+        否則返回空列表，讓優化器使用主 songs 配置
+
+        Returns:
+            歌曲配置列表，每個元素包含 music_id, difficulty, banned_cards 等
+        """
+        optimizer_config = self.get_optimizer_config()
+        return optimizer_config.get("songs", [])
+
     def print_summary(self):
         """列印配置摘要"""
         logger.info("=" * 60)

--- a/src/core/RCardData.py
+++ b/src/core/RCardData.py
@@ -96,6 +96,12 @@ def convert_all_yaml_files():
 
 
 def db_load(path):
+    # 優先從 GameData 載入（用於打包後的應用程式），找不到才從原路徑載入
+    if path.startswith("Data"):
+        gamedata_path = path.replace("Data", "GameData", 1)
+        if os.path.exists(gamedata_path):
+            path = gamedata_path
+
     with open(path, 'r', encoding='UTF-8') as f:
         return json.load(f)
 

--- a/src/core/RChart.py
+++ b/src/core/RChart.py
@@ -75,7 +75,11 @@ class MusicDB:
         self.db: List[Music] = []  # Stores all Music objects
         self._id_map: Dict[int, Music] = {}  # Optimized for ID lookups
 
-        if not os.path.exists(yaml_filepath):
+        # 優先從 GameData 載入（用於打包後的應用程式），找不到才從 Data 載入
+        gamedata_path = os.path.join("GameData", "Musics.yaml")
+        if os.path.exists(gamedata_path):
+            yaml_filepath = gamedata_path
+        elif not os.path.exists(yaml_filepath):
             raise FileNotFoundError(f"Music database file not found at: {yaml_filepath}")
 
         with open(yaml_filepath, encoding="UTF-8") as f:

--- a/src/core/RDeck.py
+++ b/src/core/RDeck.py
@@ -206,6 +206,10 @@ class Deck():
             appeals = [card.smile, card.pure, card.cool]
             appeals[music_type - 1] *= 10
             result += sum(appeals)
+        if self.friend:
+            appeals = [self.friend.smile, self.friend.pure, self.friend.cool]
+            appeals[music_type - 1] *= 10
+            result += sum(appeals)
         result = ceil(result / 10)
         self.appeal = result
         return result
@@ -214,6 +218,8 @@ class Deck():
         result = 0
         for card in self.cards:
             result += card.mental
+        if self.friend:
+            result += self.friend.mental
         return result
 
     def used_all_skill_calc(self):

--- a/src/core/RDeck.py
+++ b/src/core/RDeck.py
@@ -77,19 +77,10 @@ def _get_evolution(rarity: Rarity, lv: int) -> int:
     return stages[-1][1]
 
 
-def cardobj_cache(cls):
-    cache: dict[int, Card] = {}
-
-    def wrapper(*args, **kwargs):
-        key = args[2]  # 仅检查卡牌id
-        if key not in cache:
-            cache[key] = cls(*args, **kwargs)
-        return copy(cache[key])
-    return wrapper
-
-
-@cardobj_cache
 class Card():
+    _cardobj_cache = {}
+    _friend_cache = {}
+
     def __init__(self, db_card, db_skill, series_id, lv_list=None):
         if lv_list == None:
             lv_list = [140, 14, 14]
@@ -110,6 +101,36 @@ class Card():
         self.cost: int = self.skill_unit.cost
         self.active_count: int = 0
         self.is_except: bool = False
+
+    @classmethod
+    def get_instance(cls, db_card, db_skill, series_id, lv_list=None):
+        """獲取卡牌實例（使用快取）"""
+        key = series_id
+        if key not in cls._cardobj_cache:
+            # 只有第一次會執行繁瑣的資料庫查找和計算
+            cls._cardobj_cache[key] = cls(db_card, db_skill, series_id, lv_list)
+
+        # 使用 copy 返回快取的副本
+        return copy(cls._cardobj_cache[key])
+
+    @classmethod
+    def get_friend(cls, db_card, db_skill, series_id, lv_list=None):
+        """獲取助戰卡實例（滿練度，使用獨立快取）"""
+        key = series_id
+        if key not in cls._friend_cache:
+            # 助戰卡固定滿練度
+            if lv_list is None:
+                lv_list = [140, 14, 14]
+            cls._friend_cache[key] = cls(db_card, db_skill, series_id, lv_list)
+
+        # 使用 copy 返回快取的副本
+        return copy(cls._friend_cache[key])
+
+    def __copy__(self):
+        cls = self.__class__
+        new = cls.__new__(cls)
+        new.__dict__ = self.__dict__.copy()
+        return new
 
     def __str__(self) -> str:
         return (
@@ -154,8 +175,9 @@ class Deck():
         self.queue: deque[Card] = deque()
         self.appeal: int = 0
         self.card_log: list[str] = []
+        self.friend: Card = None  # 助戰卡（需要外部設定）
         for card in card_info:
-            self.cards.append(Card(db_card, db_skill, card[0], card[1]))
+            self.cards.append(Card.get_instance(db_card, db_skill, card[0], card[1]))
         self.reset()
 
     def reset(self):

--- a/src/core/Simulator_core.py
+++ b/src/core/Simulator_core.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 # 导入所有 R 模块和 db_load 函数
 from .RCardData import db_load
 from .RChart import Chart, MusicDB
@@ -27,7 +28,7 @@ except ImportError as e:
 except FileNotFoundError as e:
     logger.error(f"Required database file not found: {e}. Please check your 'Data' directory.")
     # Exit or handle gracefully if critical modules are missing/DBs not found
-    exit(1)  # Exit with an error code
+    sys.exit(1)  # Exit with an error code
 
 
 MISS_TIMING = {

--- a/src/core/Simulator_core.py
+++ b/src/core/Simulator_core.py
@@ -191,8 +191,8 @@ def run_game_simulation(
                     will_die = (player.mental.current_hp <= miss_damage)
 
                     if will_die:
-                        # 如果 MISS 會導致遊戲結束，改為 PERFECT
-                        player.combo_add("PERFECT")
+                        # 如果 MISS 會導致遊戲結束，改為 PERFECT+
+                        player.combo_add("PERFECT+")
                     else:
                         # 需要仰卧起坐时，将 MISS 时机按判定窗口延后以提高精度
                         if flag_hanabi_ginko:
@@ -221,8 +221,8 @@ def run_game_simulation(
                     will_die = (player.mental.current_hp <= miss_damage)
 
                     if will_die:
-                        # 如果 MISS 會導致遊戲結束，改為 PERFECT
-                        player.combo_add("PERFECT")
+                        # 如果 MISS 會導致遊戲結束，改為 PERFECT+
+                        player.combo_add("PERFECT+")
                     else:
                         player.combo_add("MISS", note_type)
                 else:

--- a/src/core/SkillResolver.py
+++ b/src/core/SkillResolver.py
@@ -145,6 +145,15 @@ def ApplyCenterAttribute(player_attrs: PlayerAttributes, effect_id: int, target:
     else:
         target_cards = player_attrs.deck.cards
 
+    # 助戰卡：使用助戰卡自己的角色ID進行檢查
+    friend_card = None
+    if player_attrs.deck.friend:
+        if target:
+            if CheckMultiTarget(target, player_attrs.deck.friend):
+                friend_card = player_attrs.deck.friend
+        else:
+            friend_card = player_attrs.deck.friend
+
     # 将ID解析为字符串方便操作
     id_str = str(effect_id)
 
@@ -180,6 +189,8 @@ def ApplyCenterAttribute(player_attrs: PlayerAttributes, effect_id: int, target:
             multiplier = 1 + change_amount
             for card in target_cards:
                 card.smile *= multiplier
+            if friend_card:
+                friend_card.smile *= multiplier
             if logger.isEnabledFor(logging.DEBUG):
                 action = "增加" if change_direction == 0 else "减少"
                 logger.debug(f"  对满足要求的目标应用效果: Smile值 {action} {change_amount*100:.0f}%")
@@ -189,6 +200,8 @@ def ApplyCenterAttribute(player_attrs: PlayerAttributes, effect_id: int, target:
             multiplier = 1 + change_amount
             for card in target_cards:
                 card.pure *= multiplier
+            if friend_card:
+                friend_card.pure *= multiplier
             if logger.isEnabledFor(logging.DEBUG):
                 action = "增加" if change_direction == 0 else "减少"
                 logger.debug(f"  对满足要求的目标应用效果: Pure值 {action} {change_amount*100:.0f}%")
@@ -198,6 +211,8 @@ def ApplyCenterAttribute(player_attrs: PlayerAttributes, effect_id: int, target:
             multiplier = 1 + change_amount
             for card in target_cards:
                 card.cool *= multiplier
+            if friend_card:
+                friend_card.cool *= multiplier
             if logger.isEnabledFor(logging.DEBUG):
                 action = "增加" if change_direction == 0 else "减少"
                 logger.debug(f"  对满足要求的目标应用效果: Cool值 {action} {change_amount*100:.0f}%")
@@ -207,6 +222,8 @@ def ApplyCenterAttribute(player_attrs: PlayerAttributes, effect_id: int, target:
             value_change = value_data * change_sign
             for card in target_cards:
                 card.smile += value_change
+            if friend_card:
+                friend_card.smile += value_change
             if logger.isEnabledFor(logging.DEBUG):
                 action = "增加" if change_direction == 0 else "减少"
                 logger.debug(f"  对满足要求的目标应用效果: Smile值 {action} {value_data}")
@@ -216,6 +233,8 @@ def ApplyCenterAttribute(player_attrs: PlayerAttributes, effect_id: int, target:
             value_change = value_data * change_sign
             for card in target_cards:
                 card.pure += value_change
+            if friend_card:
+                friend_card.pure += value_change
             if logger.isEnabledFor(logging.DEBUG):
                 action = "增加" if change_direction == 0 else "减少"
                 logger.debug(f"  对满足要求的目标应用效果: Pure值 {action} {value_data}")
@@ -225,6 +244,8 @@ def ApplyCenterAttribute(player_attrs: PlayerAttributes, effect_id: int, target:
             value_change = value_data * change_sign
             for card in target_cards:
                 card.cool += value_change
+            if friend_card:
+                friend_card.cool += value_change
             if logger.isEnabledFor(logging.DEBUG):
                 action = "增加" if change_direction == 0 else "减少"
                 logger.debug(f"  对满足要求的目标应用效果: Cool值 {action} {value_data}")
@@ -234,6 +255,9 @@ def ApplyCenterAttribute(player_attrs: PlayerAttributes, effect_id: int, target:
             multiplier = 1 + change_amount * change_sign
             for card in target_cards:
                 card.mental = ceil(card.mental * multiplier)
+            if friend_card:
+                from math import ceil
+                friend_card.mental = ceil(friend_card.mental * multiplier)
             if logger.isEnabledFor(logging.DEBUG):
                 action = "增加" if change_direction == 0 else "减少"
                 logger.debug(f"  对满足要求的目标应用效果: 血量 {action} {change_amount*100:.0f}%")
@@ -242,6 +266,8 @@ def ApplyCenterAttribute(player_attrs: PlayerAttributes, effect_id: int, target:
             value_change = value_data * change_sign
             for card in target_cards:
                 card.mental += value_change
+            if friend_card:
+                friend_card.mental += value_change
             if logger.isEnabledFor(logging.DEBUG):
                 action = "增加" if change_direction == 0 else "减少"
                 logger.debug(f"  对满足要求的目标应用效果: 血量 {action} {value_data}")

--- a/src/core/SkillResolver.py
+++ b/src/core/SkillResolver.py
@@ -1,6 +1,7 @@
 import logging
 from enum import Enum
 from functools import lru_cache
+from math import ceil
 from .RLiveStatus import *
 from .RDeck import Card
 
@@ -256,7 +257,6 @@ def ApplyCenterAttribute(player_attrs: PlayerAttributes, effect_id: int, target:
             for card in target_cards:
                 card.mental = ceil(card.mental * multiplier)
             if friend_card:
-                from math import ceil
                 friend_card.mental = ceil(friend_card.mental * multiplier)
             if logger.isEnabledFor(logging.DEBUG):
                 action = "增加" if change_direction == 0 else "减少"

--- a/src/deck_gen/DeckGen2.py
+++ b/src/deck_gen/DeckGen2.py
@@ -288,20 +288,20 @@ class DeckGeneratorWithDoubleCards:
             if has_card_conflict(set(deck)):
                 continue
             if self.check_skill_tags(count_skill_tags(deck), self.force_dr):
-                # 找出所有 C 位角色的卡片（用於指定隊長）
-                center_cards = []
-                if self.center_char:
-                    for i, card_id in enumerate(deck):
-                        char_id = card_id // 1000
-                        if char_id == self.center_char:
-                            center_cards.append(i)
-
-                # 如果沒有 C 位卡，使用 -1 表示自動選擇
-                if not center_cards:
-                    center_cards = [-1]
-
                 # 使用优化的排列生成器，避免生成无效排列
                 for perm in self._generate_valid_permutations(deck):
+                    # 找出排列後所有 C 位角色的卡片索引（用於指定隊長）
+                    center_cards = []
+                    if self.center_char:
+                        for i, card_id in enumerate(perm):
+                            char_id = card_id // 1000
+                            if char_id == self.center_char:
+                                center_cards.append(i)
+
+                    # 如果沒有 C 位卡，使用 -1 表示自動選擇
+                    if not center_cards:
+                        center_cards = [-1]
+
                     # 為每個 C 位卡生成一個卡組
                     for center_card_index in center_cards:
                         # 助戰卡迴圈


### PR DESCRIPTION
新增功能：
- MainBatch.py: 支援在歌曲配置中設定 banned_cards
- multi_optimizer_2.py: 支援優化器專屬歌曲配置和每首歌的禁卡
- 自動合併全局禁卡和每首歌的禁卡設定

修改文件：
- src/deck_gen/DeckGen2.py: 新增 banned_cards 參數，在卡組生成時排除禁卡
- MainBatch.py: 讀取並傳遞 banned_cards 配置給卡組生成器
- multi_optimizer_2.py: 支援 optimizer.songs 配置和每首歌的禁卡過濾
- src/config/config_manager.py: 新增 get_optimizer_songs() 方法
- config/*.yaml: 更新所有配置範例，添加 banned_cards 欄位和說明